### PR TITLE
Fix for Moose 1.99+

### DIFF
--- a/lib/CHI/Driver/Metacache.pm
+++ b/lib/CHI/Driver/Metacache.pm
@@ -4,7 +4,7 @@ use Moose;
 use strict;
 use warnings;
 
-has 'meta_cache'      => ( is => 'ro', builder => '_build_meta_cache' );
+has 'meta_cache'      => ( is => 'ro', lazy_build => 1 );
 has 'owner_namespace' => ( is => 'ro', lazy_build => 1 );
 has 'owner_cache'     => ( is => 'ro', weak_ref => 1 );
 


### PR DESCRIPTION
It would be great if you could release a new version with this fix some time soon. That will make the code work with both current Moose and 1.99+.

I think this particular code only worked accidentally anyway.
