### PR TITLE
The CHI:Driver:FastMmap uses the Cache::FastMmap but the last is missed ...

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -55,6 +55,7 @@ Task::Weaken              = 0
 Time::Duration            = 1.06
 Time::Duration::Parse     = 0.03
 Try::Tiny                 = 0.05
+Cache::FastMmap           = 0
 
 [Prereqs / TestRequires]
 Date::Parse                 = 0


### PR DESCRIPTION
...in prereq. This patch fixes it
