### PR TITLE
Allow global=>0 as an option to the Memory driver.

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,13 @@ Revision history for CHI
 
 ** denotes an incompatible change
 
+NEXT VERSION
+
+* Improvements
+  - The Memory driver (and RawMemory for that matter) now support zero as a
+    valid value for the global argument causing a new hashref datastore to
+    be created. (Aran Deltac)
+
 0.58  July 21, 2013
 
 * Fixes

--- a/lib/CHI/Driver/Memory.pm
+++ b/lib/CHI/Driver/Memory.pm
@@ -24,10 +24,10 @@ sub default_discard_policy { 'lru' }
 sub BUILD {
     my ( $self, $params ) = @_;
 
-    if ( $self->{global} ) {
+    if (defined $self->{global}) {
         croak "cannot specify both 'datastore' and 'global'"
           if ( defined( $self->{datastore} ) );
-        $self->{datastore} = \%Global_Datastore;
+        $self->{datastore} = $self->{global} ? \%Global_Datastore : {};
     }
     if ( !defined( $self->{datastore} ) ) {
         cluck "must specify either 'datastore' hashref or 'global' flag";
@@ -108,6 +108,8 @@ CHI::Driver::Memory - In-process memory based cache
 
     my $cache = CHI->new( driver => 'Memory', global => 1 );
 
+    my $cache = CHI->new( driver => 'Memory', global => 0 );
+
 =head1 DESCRIPTION
 
 This cache driver stores data on a per-process basis.  This is the fastest of
@@ -137,10 +139,13 @@ CHI::Driver::Memory constructors.
 
 =item global [BOOL]
 
-Use a standard global datastore. Multiple caches created with this flag will
-see the same data. Before 0.21, this was the default behavior; now it must be
-specified explicitly (to avoid accidentally sharing the same datastore in
-unrelated code).
+Use a standard global datastore. Multiple caches created with this set to true
+will see the same data. Before 0.21, this was the default behavior; now it
+must be specified explicitly (to avoid accidentally sharing the same datastore
+in unrelated code).
+
+If this is set to false then datastore will be set to a new reference to a
+hash.
 
 =back
 

--- a/lib/CHI/Driver/RawMemory.pm
+++ b/lib/CHI/Driver/RawMemory.pm
@@ -32,6 +32,8 @@ CHI::Driver::RawMemory - In-process memory cache that stores direct references
 
     my $cache = CHI->new( driver => 'RawMemory', global => 1 );
 
+    my $cache = CHI->new( driver => 'RawMemory', global => 0 );
+
 =head1 DESCRIPTION
 
 This is a subclass of L<CHI::Driver::Memory|CHI::Driver::Memory> that stores

--- a/lib/CHI/t/Driver/Memory.pm
+++ b/lib/CHI/t/Driver/Memory.pm
@@ -17,12 +17,16 @@ sub new_cache_options {
 
 sub new_cache {
     my $self   = shift;
-    my %params = @_;
+
+    my %params = (
+        $self->new_cache_options(),
+        @_
+    );
 
     # If new_cache called with datastore, ignore global flag (otherwise would be an error)
     #
     if ( $params{datastore} ) {
-        $params{global} = 0;
+        delete $params{global};
     }
 
     # Check test key validity on every get and set - only necessary to do for one driver
@@ -30,7 +34,7 @@ sub new_cache {
     $params{roles}       = ['+CHI::Test::Driver::Role::CheckKeyValidity'];
     $params{test_object} = $self;
 
-    my $cache = CHI->new( $self->new_cache_options(), %params );
+    my $cache = CHI->new( %params );
     return $cache;
 }
 
@@ -59,6 +63,16 @@ sub test_different_datastores : Tests {
     my $self   = shift;
     my $cache1 = CHI->new( driver => 'Memory', datastore => {} );
     my $cache2 = CHI->new( driver => 'Memory', datastore => {} );
+    $self->set_some_keys($cache1);
+    ok( !$cache2->get_keys() );
+}
+
+# Make sure two global=0 caches don't share datastore
+#
+sub test_different_global_0 : Tests {
+    my $self   = shift;
+    my $cache1 = CHI->new( driver => 'Memory', global => 0 );
+    my $cache2 = CHI->new( driver => 'Memory', global => 0 );
     $self->set_some_keys($cache1);
     ok( !$cache2->get_keys() );
 }

--- a/lib/CHI/t/Driver/RawMemory.pm
+++ b/lib/CHI/t/Driver/RawMemory.pm
@@ -7,15 +7,19 @@ use base qw(CHI::t::Driver::Memory);
 
 sub new_cache {
     my $self   = shift;
-    my %params = @_;
+
+    my %params = (
+        $self->new_cache_options(),
+        @_,
+    );
 
     # If new_cache called with datastore, ignore global flag (otherwise would be an error)
     #
     if ( $params{datastore} ) {
-        $params{global} = 0;
+        delete $params{global};
     }
 
-    my $cache = CHI->new( $self->new_cache_options(), %params );
+    my $cache = CHI->new( %params );
     return $cache;
 }
 


### PR DESCRIPTION
I like to declare my CHI configuration in static configuration files.  This has issues with the Memory driver in particular as I almost always want a local datastore.  But, the only way to declare a local datastore is by passing a hashref.  I can't create a new hashref in the configuration, that just doesn't make sense.  The alternative I have is to have code that injects a new hashref after loading the config, but before calling CHI->new(), and thats just cumbersome.

The way I thought it would work, but turns out it doesn't, is by passing global=>0, implying no globalness.  Since that doesn't work, I implemented it.

I hope you like.  Let me know if you want any changes.
