### PR TITLE
Pass the driver to the expire_if function

### DIFF
--- a/lib/CHI.pm
+++ b/lib/CHI.pm
@@ -479,7 +479,7 @@ I<$key> may be followed by one or more name/value parameters:
 =item expire_if [CODEREF]
 
 If I<$key> exists and has not expired, call code reference with the
-L<CHI::CacheObject|CHI::CacheObject> as a single parameter. If code returns a
+L<CHI::CacheObject|CHI::CacheObject> and L<CHI::Driver|CHI::Driver> as the parameters. If code returns a
 true value, C<get> returns undef as if the item were expired. For example, to
 treat the cache as expired if I<$file> has changed since the value was
 computed:

--- a/lib/CHI/Driver.pm
+++ b/lib/CHI/Driver.pm
@@ -285,7 +285,7 @@ sub get {
     # Check if expired
     #
     my $is_expired = $obj->is_expired()
-      || ( defined( $params{expire_if} ) && $params{expire_if}->($obj) );
+      || ( defined( $params{expire_if} ) && $params{expire_if}->($obj, $self) );
     if ($is_expired) {
         $self->_record_get_stats( 'expired_misses', $elapsed_time )
           if defined($ns_stats);


### PR DESCRIPTION
It is useful to have the driver when deciding to expire an item when using a l1_cache.