### PR TITLE
Stop serializing in the Null driver.

### DIFF
--- a/lib/CHI/Driver/Null.pm
+++ b/lib/CHI/Driver/Null.pm
@@ -6,6 +6,8 @@ use warnings;
 
 extends 'CHI::Driver';
 
+has 'serializer' => ( is => 'ro', init_arg => undef );
+
 sub fetch          { undef }
 sub store          { undef }
 sub remove         { undef }


### PR DESCRIPTION
There is no reason the Null driver should be serializing, its just a waste of cycles, and in my case the objects involved go *boom* when serialized.  Copied from RawMemory, so most my work was testing. :)