### PR TITLE
Add `no_defaults_for' attribute to fix subcache get/set infinite recursion

### DIFF
--- a/lib/CHI.pm
+++ b/lib/CHI.pm
@@ -6,6 +6,7 @@ use CHI::Stats;
 use String::RewritePrefix;
 use Module::Runtime qw(require_module);
 use Moo::Role ();
+use Hash::MoreUtils qw(slice_grep);
 use strict;
 use warnings;
 
@@ -34,6 +35,81 @@ sub _set_config {
     no strict 'refs';
     no warnings 'redefine';
     *{"$class\::_get_config"} = sub { $config };
+}
+
+sub _defaults {
+    my ( $class, $params, $config ) = @_;
+
+    $params ||= {};
+    $config ||= $class->config || {};
+
+    my $no_defaults_for;
+    if ( my $reftype = ref( $no_defaults_for = $params->{no_defaults_for} ) ) {
+        croak "'no_defaults_for' must be an array reference or string"
+          unless $reftype eq 'ARRAY';
+    }
+    else {
+        $no_defaults_for = [ $no_defaults_for || () ];
+    }
+
+    # Create a hash that maps top-level constructor keys to '1' for each
+    # attribute that should not have a default value loaded from core,
+    # namespace, or storage defaults.
+    #
+    my %no_defaults_for_map = map { $_ => 1 } @$no_defaults_for;
+
+    # Returns a hash reference containing each key => value pair from the
+    # provided hash reference for which '$no_defaults_for{$key}' does not
+    # evaluate to '1'.
+    #
+    my $filter_default_values = sub {
+        return {} unless defined $_[0];
+        return { slice_grep { !$no_defaults_for_map{$_} } $_[0] };
+    };
+
+    # Takes a key into the '$params' hash reference and an optional default
+    # value in case '$params' does not contain the provided key.  Looks up the
+    # resolved key in the '$config' hash reference, returning a hash reference
+    # containing all key => value pairs for which '$no_defaults_for{$key}'
+    # does not evaluate to '1'.  If the provided key cannot be found in
+    # '$params' and the default value is undefined, returns an empty hash
+    # reference.
+    #
+    # For example:
+    #
+    #   $params = {namespace => 'Foo'};
+    #   $config = {namespace => {Foo => {storage => 'File'}
+    #   $no_defaults_for => ['label'];
+    #   $defaults = $extract_defaults->('namespace', 'Default');
+    #       # $defaults == {storage => 'File'}
+    #
+    my $extract_defaults = sub {
+        my ( $key, $fallback ) = @_;
+
+        my $found = $params->{$key};
+        $found ||= $fallback unless $no_defaults_for_map{$key};
+
+        return {} unless defined $found;
+
+        return $filter_default_values->( $config->{$key}{$found} );
+    };
+
+    my $core_defaults = $filter_default_values->( $config->{defaults} );
+
+    my $namespace_defaults = $extract_defaults->( 'namespace', 'Default' );
+
+    my $storage_defaults = $extract_defaults->(
+        'storage', $namespace_defaults->{storage} || $core_defaults->{storage},
+    );
+
+    return ( $core_defaults, $storage_defaults, $namespace_defaults );
+}
+
+# Merges the hash references returned by '_defaults', preferring namespace
+# defaults to storage defaults and storage defaults to core defaults.
+#
+sub defaults {
+    return { map { %$_ } &_defaults };
 }
 
 BEGIN { __PACKAGE__->config( {} ) }
@@ -80,25 +156,15 @@ sub new {
         }
     }
 
-    # Gather defaults
+    # Combine passed-in arguments with defaults
     #
-    my $core_defaults = $config->{defaults} || {};
-    my $namespace_defaults =
-      $config->{namespace}->{ $params{namespace} || 'Default' } || {};
-    my $storage =
-         $params{storage}
-      || $namespace_defaults->{storage}
-      || $core_defaults->{storage};
-    my $storage_defaults = {};
-    if ( defined($storage) ) {
-        $storage_defaults = $config->{storage}->{$storage}
-          or croak "no config for storage type '$storage'";
-    }
+    my $defaults = $chi_root_class->defaults( \%params, $config );
+    %params = ( %$defaults, %params );
 
-    # Combine passed params with defaults
-    #
-    %params =
-      ( %$core_defaults, %$storage_defaults, %$namespace_defaults, %params );
+    my $storage = $params{storage};
+    if ( defined $storage && !exists $config->{storage}{$storage} ) {
+        croak "no config for storage type '$storage'";
+    }
 
     # Get driver class from driver or driver_class parameters
     #
@@ -200,7 +266,7 @@ CHI - Unified cache handling interface
     );
 
     # Create your own driver
-    # 
+    #
     my $cache = CHI->new( driver => '+My::Special::Driver', ... );
 
     # Cache operations
@@ -455,7 +521,30 @@ C<CHI::Driver::Role::> unless preceded with a '+'. e.g.
 
     traits => ['StoresAccessedAt', '+My::CHI::Driver::Role']
 
-=back    
+=item no_defaults_for [LISTREF]
+
+List of one or more default settings (see L</SUBCLASSING AND CONFIGURING CHI>)
+to ignore when instantiating the object.
+
+    My::CHI->config({
+        storage => {
+            local_file => { driver => 'File', root_dir => '/my/root' },
+        },
+        defaults => {
+            storage => 'local_file',
+            label   => 'static-assets',
+        },
+    });
+
+    My::CHI->new->label;                                    # "static-assets"
+    My::CHI->new( no_defaults_for => ['label'] )->label;    # "File"
+
+Duplicate values are removed upon assignment:
+
+    my $cache = My::CHI->new(no_defaults_for => [qw(storage storage storage)])
+    $cache->no_defaults_for;    # ["storage"]
+
+=back
 
 =head1 INSTANCE METHODS
 
@@ -823,6 +912,7 @@ e.g.
 
     namespace
     serializer
+    no_defaults_for
 
 =back
 
@@ -1418,7 +1508,7 @@ from the logs and report a summary. See L<CHI::Stats|CHI::Stats> for details.
 CHI is intended as an evolution of DeWitt Clinton's
 L<Cache::Cache|Cache::Cache> package. It starts with the same basic API (which
 has proven durable over time) but addresses some implementation shortcomings
-that cannot be fixed in Cache::Cache due to backward compatibility concerns. 
+that cannot be fixed in Cache::Cache due to backward compatibility concerns.
 In particular:
 
 =over

--- a/lib/CHI/Driver.pm
+++ b/lib/CHI/Driver.pm
@@ -139,6 +139,11 @@ my @common_params;
         storage => {
             is => 'ro',
         },
+        no_defaults_for => {
+            is     => 'ro',
+            isa    => ArrayRef [Str],
+            coerce => \&to_UniqArrayRef,
+        },
     );
     push @common_params, keys %attr;
     for my $attr ( keys %attr ) {

--- a/lib/CHI/Types.pm
+++ b/lib/CHI/Types.pm
@@ -2,6 +2,7 @@ package CHI::Types;
 
 use Carp;
 use CHI::Util qw(can_load parse_duration parse_memory_size);
+use List::MoreUtils qw(uniq);
 use MooX::Types::MooseLike qw(exception_message);
 use MooX::Types::MooseLike::Base qw(:all);
 use MooX::Types::MooseLike::Numeric qw(:all);
@@ -124,6 +125,25 @@ sub to_Digester {
     }
 }
 push @EXPORT_OK, 'to_Digester';
+
+# Strip duplicates from an array reference.  Also accepts a single string.
+# Passes through any values other than array references so that they can be
+# caught by 'isa' constraints.
+#
+sub to_UniqArrayRef {
+    my $from = shift;
+
+    if ( is_ArrayRef($from) ) {
+        [ uniq @$from ];
+    }
+    elsif ( is_Str($from) ) {
+        [$from];
+    }
+    else {
+        return $from;
+    }
+}
+push @EXPORT_OK, 'to_UniqArrayRef';
 
 my $data_serializer_loaded = can_load('Data::Serializer');
 

--- a/lib/CHI/t/Driver.pm
+++ b/lib/CHI/t/Driver.pm
@@ -222,6 +222,17 @@ sub test_driver_class : Tests {
     can_ok( $cache, 'get', 'set', 'remove', 'clear', 'expire' );
 }
 
+sub test_no_defaults_for : Tests {
+    my $self = shift;
+
+    my $cache1 = $self->new_cache( no_defaults_for => [ qw(storage) x (3) ] );
+    is_deeply( $cache1->no_defaults_for, [qw(storage)], 'duplicates removed' );
+
+    my $cache2 = $self->new_cache( no_defaults_for => 'label' );
+    is_deeply( $cache2->no_defaults_for, [qw(label)],
+        'coerces string to arrayref' );
+}
+
 sub test_key_types : Tests {
     my $self  = shift;
     my $cache = $self->{cache};


### PR DESCRIPTION
CHI subclasses that define one or more subcaches using `defaults`, `namespace`, or `storage` are susceptible to infinite recursion upon `get` and `set`.  Consider `l1_loop.pl`:

``` perl
#!/usr/bin/env perl

use strict;
use warnings;

package My::CHI;                                   

use base 'CHI';                                    

__PACKAGE__->config({                              
    storage => {                                   
        local_file => {                                  
            driver      => 'File',                 
            root_dir    => '/tmp/mychi',           
        },
        raw_memory => {
               driver => 'RawMemory',
               global => 0,
        },                                       
    },                                             
    defaults => {                                  
        storage => 'local_file',                         
        l1_cache    => {                           
            storage => 'raw_memory',                     
        },                                         
    },                                             
});                                                

package main;                                      

my $cache = My::CHI->new;                          
$cache->set('it', 'off');
```

``` shell
$ ./l1_loop.pl
Deep recursion on subroutine "Role::Tiny::_COMPOSABLE::CHI::Driver::Role::HasSubcaches::set" at /home/matt/git/perl-chi/lib/CHI/Driver/Role/HasSubcaches.pm line 88.
Deep recursion on anonymous subroutine at (eval 42) line 16.
^C
```

The reason is that the subcache is instantiated using the same defaults as the parent cache, so will have its own subcache, which has its own subcache, which has its own subcache, all the way down.  This manifests as recursion on the `anonymous subroutine`s defined with `before` and `around` in `CHI::Driver::Role::HasSubcaches`.

This pull requests addresses the infinite recursion issue by adding the constructor param `no_defaults_for`, which allows specifying a list of keys to delete from the  `defaults`, `namespace`, and `storage` hashrefs prior to instantiating a CHI subclass instance.  All subcaches get `l1_cache` and `mirror_cache` automatically appended to `no_defaults_for` -- only the parent cache can have subcaches defined from package defaults.

Thanks in advance for considering this pull request!

---

P.S.: I got the following error when running `dzil build`:

``` shell
$ dzil build
Can't call method "content" on an undefined value at /home/matt/opt/perl5/perlbrew/perls/perl-5.20.0/lib/site_perl/5.20.0/Dist/Zilla/Plugin/MakeMaker.pm line 318.
```

I fixed this by editing `dist.ini` to remove `filenames = Makefile.PL` from `[PruneFiles]` and add `exclude_filename = Makefile.PL` to `[GatherDir]`.  The real culprit might be some environment muck-up on my part -- please let me know :).
