### PR TITLE
Update perlpod link to CHI/INSTANCE METHODS

### DIFF
--- a/lib/CHI/Driver.pm
+++ b/lib/CHI/Driver.pm
@@ -852,7 +852,7 @@ CHI::Driver - Base class for all CHI drivers
 This is the base class that all CHI drivers inherit from. It provides the
 methods that one calls on $cache handles, such as get() and set().
 
-See L<CHI/METHODS> for documentation on $cache methods, and
+See L<CHI/INSTANCE METHODS> for documentation on $cache methods, and
 L<CHI::Driver::Development|CHI::Driver::Development> for documentation on
 creating new subclasses of CHI::Driver.
 


### PR DESCRIPTION
The perlpod link [`L<CHI/METHODS>`](https://metacpan.org/pod/CHI#METHODS) no longer points to a section in this module.

The closest section seems to be [`L<CHI/INSTANCE METHODS>`](https://metacpan.org/pod/CHI#INSTANCE-METHODS).

I'm a little unsure, though, since this section header was committed 12 years ago.